### PR TITLE
Fix a not working command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ zip bae-i4trust-service.zip package.json i4trust_service.py
 
 Copy the zip file to the `/plugins` directory of your charging backend component and load the plugin:
 ```shell
-manage.py loadplugin plugins/i4trust_service.py
+./manage.py loadplugin plugins/bae-i4trust-service.zip
 ```


### PR DESCRIPTION
Fixes the command to enable the plugin in the readme.

```
manage.py loadplugin bae-i4trust-service/i4trust_service.py
```

> bash: manage.py: command not found

```
./manage.py loadplugin bae-i4trust-service/i4trust_service.py
```

> CommandError: Plugin Error: Invalid package format: Not a zip file